### PR TITLE
Update inrupt.net version to NSS 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 |               Link                |    Responsible for Domain Name and Terms of Use     |             Responsible for Hosting               | Location of Hosting | Solid Server Version |
 |-----------------------------------|:---------------------------------------------------:|:-------------------------------------------------:|:-------------------:|:--------------------:|
-| https://inrupt.net/               | [Inrupt, Inc.](https://inrupt.com/terms-of-service) |         [Amazon](https://aws.amazon.com)          |         USA         |          NSS 4.x          |
+| https://inrupt.net/               | [Inrupt, Inc.](https://inrupt.com/terms-of-service) |         [Amazon](https://aws.amazon.com)          |         USA         |          NSS 5.x          |
 | https://solid.community/| ?? | ?? |         ??          |           NSS 4.x          |
 
 


### PR DESCRIPTION
As far as I've seen inrupt.net uses NSS 5.1.5 currently, I get following response header when requesting a file on my inrupt.net pod: `X-Powered-By: solid-server/5.1.5`